### PR TITLE
refactor: use .env to store DISCORD_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DISCORD_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 *.sh
 *.db
 *.log
+.env
+
+# virtualenv folder name
 env/
-.idea/
+
+# ide-specific
+.vscode
+.idea

--- a/Main.py
+++ b/Main.py
@@ -14,6 +14,7 @@ import sys
 import traceback
 
 from discord.ext import commands
+from dotenv import load_dotenv
 from matplotlib import pyplot as plt
 from typing import Optional, Tuple
 
@@ -483,6 +484,9 @@ async def link(ctx):
 
 
 def main():
+    # Load environment variables from .env file
+    load_dotenv()
+
     # Create the database with the required tables if needed
     with open("./schema.sql", "r") as sf:
         conn = sqlite3.connect(DB_PATH)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ numpy==1.19.1
 Pillow==7.2.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
+python-dotenv==0.16.0
 pytz==2020.1
 six==1.15.0
 tabulate==0.8.7


### PR DESCRIPTION
Leverages the [`python_dotenv`](https://pypi.org/project/python-dotenv/) package to load environment variables from a gitignored `.env` file.

`.env.example` gives the user a template to fill in their own `.env`.