### PR TITLE
fix: clarify %addtime replace message

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -211,9 +211,9 @@ async def addtime(ctx, time: str = None):
 
         # Decide to REPLACE or INSERT based on if a score already exists at datestamp
         has_record = c.execute(
-            "SELECT EXISTS (SELECT 1 FROM Scores WHERE ID = ? AND Date= ?)",
+            "SELECT 1 FROM Scores WHERE ID = ? AND Date= ?",
             (member.id, _as_ymd(datestamp))
-        ).fetchone()[0] # the tuple returned is either (1,) or (0,)
+        ).fetchone() # the tuple returned is either (1,) or None
         command = ("REPLACE", "overwritten") if has_record else ("INSERT", "added")
 
         c.execute(f"{command[0]} INTO Scores VALUES (?, ?, ?, ?)",

--- a/Main.py
+++ b/Main.py
@@ -209,10 +209,17 @@ async def addtime(ctx, time: str = None):
 
         day = _get_day(datestamp)
 
-        c.execute("INSERT OR REPLACE INTO Scores VALUES (?, ?, ?, ?)",
+        # Decide to REPLACE or INSERT based on if a score already exists at datestamp
+        has_record = c.execute(
+            "SELECT EXISTS (SELECT 1 FROM Scores WHERE ID = ? AND Date= ?)",
+            (member.id, _as_ymd(datestamp))
+        ).fetchone()[0] # the tuple returned is either (1,) or (0,)
+        command = ("REPLACE", "overwritten") if has_record else ("INSERT", "added")
+
+        c.execute(f"{command[0]} INTO Scores VALUES (?, ?, ?, ?)",
                   (member.id, member.name, _as_ymd(datestamp), time))
         conn.commit()
-        await ctx.send("```css\nScore added.\n```")
+        await ctx.send(f"```css\nScore for {_as_ymd(datestamp)} {command[1]}.\n```")
 
         # Update averages and attach them to the message
 


### PR DESCRIPTION
Complicates the logic for `%addtime` in order to provide clarity to what the command does if today's crossword was already entered once.

Please give feedback on SQL or code style! I'm not sure if the query I wrote is the best way to coerce a 0 or 1 out of whether a record exists or not.