### PR TITLE
docs: add venv activation to README guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ crosswords and the regular ones.
 git clone https://github.com/idoneam/minicrossword-bot.git
 cd minicrossword-bot
 
-# Set up a virtualenv named `env` (replace python3 with python on Windows)
-python3 -m virtualenv env
+# Set up a virtualenv named `env`
+python -m virtualenv env
 
 # Activate the virtual environment (just run env/bin/activate, without the source prefix on Windows)
 source env/bin/activate

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ crosswords and the regular ones.
 
 ```bash
 # Clone the repository
-git clone https://github.com/idoneam/minicrossword-bot.git
-cd minicrossword-bot
+git clone https://github.com/idoneam/minicrossword-bot.git && cd minicrossword-bot
 
 # Set up a virtualenv named `env`
 python -m virtualenv env

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd minicrossword-bot
 # Set up a virtualenv named `env` (replace python3 with python on Windows)
 python3 -m virtualenv env
 
-# Activate the virtual environment
+# Activate the virtual environment (just run env/bin/activate, without the source prefix on Windows)
 source env/bin/activate
 
 # Install dependencies
@@ -48,7 +48,7 @@ DISCORD_TOKEN=####################
 
 Start up the main Python file:
 ```bash
-# Activate virtual environment
+# Activate the virtual environment (just run env/bin/activate, without the source prefix on Windows)
 source env/bin/activate
 
 # Run bot

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ crosswords and the regular ones.
 git clone https://github.com/idoneam/minicrossword-bot.git
 cd minicrossword-bot
 
-# Set up a virtualenv named `env`
-virtualenv env   
+# Set up a virtualenv named `env` (replace python3 with python on Windows)
+python3 -m virtualenv env
+
+# Activate the virtual environment
+source env/bin/activate
 
 # Install dependencies
-pip3 install -r requirements.txt
+pip install -r requirements.txt
 
 # Create .env file from .env.example
 cp .env.example .env
@@ -45,6 +48,10 @@ DISCORD_TOKEN=####################
 
 Start up the main Python file:
 ```bash
+# Activate virtual environment
+source env/bin/activate
+
+# Run bot
 python Main.py
 ```
 


### PR DESCRIPTION
fixes issue in `README` installation and use steps where virtual environment wasn't being activated 